### PR TITLE
Bump up max width of Zammad helpdesk forms

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1440,3 +1440,11 @@ font-color:  var(--color-sdsa-black-light);
 .js-toc-content article h1, .js-toc-content article h2, .js-toc-content article h3, .js-toc-content article h4, .js-toc-content article h5, .js-toc-content article h6 {
 padding-top: 3rem;
 }
+
+/******************************************************************
+26. Zammad HelpDesk forms
+******************************************************************/
+.zammad-form-modal-body {
+    /* Override default width to allow form to be larger */
+  max-width: 60em !important;
+}


### PR DESCRIPTION
This PR changes the max-height value of Zammad modal forms from `26em` to `60em`. We have lots of data in these forms, and so having them so narrow can be troublesome for the user. The default width is `90%`, so at most it will fill up that % of the screen's width. I may need to add this manually to the `style.min.css`? :sweat_smile: I'm not sure.
